### PR TITLE
concat mcp display name

### DIFF
--- a/src/mcp/mcpProvider.ts
+++ b/src/mcp/mcpProvider.ts
@@ -24,7 +24,7 @@ export class TodoMCPServerProvider implements vscode.McpServerDefinitionProvider
 
     return [
       new vscode.McpHttpServerDefinition(
-        'Agent TODOs',
+        'AgentTODOs',
         vscode.Uri.parse(`http://localhost:${this.serverPort}/mcp`)
       )
     ];

--- a/src/test/mcp/mcpProvider.test.ts
+++ b/src/test/mcp/mcpProvider.test.ts
@@ -33,7 +33,7 @@ suite('MCP Provider Tests', () => {
         assert.ok(definitions[0] instanceof vscode.McpHttpServerDefinition);
 
         const httpDef = definitions[0] as vscode.McpHttpServerDefinition;
-        assert.strictEqual(httpDef.label, 'Agent TODOs');
+        assert.strictEqual(httpDef.label, 'AgentTODOs');
         assert.ok(httpDef.uri.toString().includes('http://localhost:'));
         assert.ok(httpDef.uri.toString().includes('/mcp'));
     });


### PR DESCRIPTION
Removes a space in the MCP server display name 

<img width="878" alt="Screenshot 2025-07-07 at 12 26 38 PM" src="https://github.com/user-attachments/assets/a3622127-6077-496d-972d-b21b3388e966" />

This way, it's parsed properly in VS Code chat:

<img width="302" alt="Screenshot 2025-07-07 at 12 26 42 PM" src="https://github.com/user-attachments/assets/8bb6e971-8dfd-4c9d-800e-5f5a62f2c86d" />

With this change, VS Code properly renders the `#`

<img width="478" alt="image" src="https://github.com/user-attachments/assets/767c1c8d-c8f6-47b6-8faa-d3f1c63ca221" />
