### PR TITLE
fix: prevent frontmatter accumulation and update autoInject defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,7 @@
+<todos title="Todos" rule="Review steps frequently throughout the conversation and DO NOT stop between steps unless they explicitly require it.">
+- No current todos
+</todos>
+
 This is a VS Code extension project. Please use the get_vscode_api with a query as input to fetch the latest VS Code API references.
 
 IMPORTANT:
@@ -60,7 +64,7 @@ graph TB
 
     subgraph ExternalInterfaces[External Interfaces]
         VSC[VS Code API]
-        CI[copilot-instructions.md]
+        CI[todos.instructions.md]
         MC[MCP Clients<br/>AI Assistants]
         MCPAPI[VS Code MCP API]
     end
@@ -319,7 +323,7 @@ Available implementations:
 
 ### Export Pattern
 
-The copilot-instructions.md file is treated as a write-only export destination, not a storage backend:
+The instructions file is treated as a write-only export destination, not a storage backend:
 
 ```typescript
 // VS Code mode: Uses CopilotInstructionsManager
@@ -450,7 +454,7 @@ const configDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
       config: {
         autoInject: config.get<boolean>('autoInject', false),
         enableSubtasks: config.get<boolean>('enableSubtasks', true),
-        autoInjectFilePath: config.get<string>('autoInjectFilePath', '.github/copilot-instructions.md')
+        autoInjectFilePath: config.get<string>('autoInjectFilePath', '.github/instructions/todos.instructions.md')
       },
       timestamp: Date.now()
     });
@@ -542,7 +546,7 @@ See [`package.json`](../package.json) for full configuration:
   - Configuration commands (auto-inject, auto-open view)
 - **Configuration**: Settings under `agentTodos.*` namespace including:
   - `agentTodos.autoInject` - Enable write-only export to copilot instructions file
-  - `agentTodos.autoInjectFilePath` - Configurable file path for auto-injection (default: `.github/copilot-instructions.md`)
+  - `agentTodos.autoInjectFilePath` - Configurable file path for auto-injection (default: `.github/instructions/todos.instructions.md`)
   - `agentTodos.autoOpenView` - Automatically open todo view when list changes
   - `agentTodos.enableSubtasks` - Enable subtasks feature
 

--- a/implementation-plan.md
+++ b/implementation-plan.md
@@ -1,0 +1,257 @@
+# Implementation Plan: AutoInject Feature Updates
+
+## Executive Summary
+
+This plan covers changing the autoInject feature to write to `.github/instructions/todos.instructions.md` instead of `.github/copilot-instructions.md`, and adding the required frontmatter template with the `applyTo: '**'` directive before the `<todos>` XML section.
+
+## Codebase Analysis
+
+### Current Architecture
+The autoInject feature currently uses:
+- **CopilotInstructionsManager** (VS Code mode) - handles file operations via VS Code APIs
+- **StandaloneCopilotWriter** (standalone MCP mode) - handles file operations via Node.js fs APIs
+- **Configuration**: `agentTodos.autoInjectFilePath` setting with default `.github/copilot-instructions.md`
+- **Template**: Direct XML `<todos>` section prepended to existing content
+
+### Key Components Identified
+- `src/copilotInstructionsManager.ts`: VS Code file operations
+- `src/mcp/standaloneCopilotWriter.ts`: Standalone file operations  
+- `package.json`: Configuration schema and default value
+- `src/todoManager.ts`: Configuration reading logic
+- `src/mcp/standaloneTodoManager.ts`: Configuration handling for standalone mode
+
+### Current Template Structure
+```xml
+<todos title="${title}" rule="Review steps frequently throughout the conversation and DO NOT stop between steps unless they explicitly require it.">
+${todoMarkdown}
+</todos>
+```
+
+## Requirements Understanding
+
+### Primary Changes Required
+1. **Default File Path Change**: `.github/copilot-instructions.md` → `.github/instructions/todos.instructions.md`
+2. **Template Enhancement**: Add frontmatter before the `<todos>` XML section:
+   ```yaml
+   ---
+   applyTo: '**'
+   ---
+   ```
+
+### Key Constraints
+- Change default behavior for all users (no backward compatibility)
+- Preserve existing frontmatter if present, add if missing
+- Handle directory creation for the new nested structure
+- Support both absolute and relative paths as before
+- Maintain the write-only pattern (never read back from the file)
+
+## Implementation Strategy
+
+### Recommended Approach
+**Direct update strategy** - Update default configuration and template format for all users.
+
+**Key Benefits:**
+- Cleaner implementation without compatibility layers
+- All users get consistent new behavior
+- Simpler code maintenance
+- Clear migration path
+
+### Alternative Approaches Considered
+- **Migration approach**: Auto-migrate existing files from old to new location
+  - **Pros**: Preserves user data location
+  - **Cons**: Complex migration logic, risk of data loss
+- **Backward compatibility approach**: Support both old and new formats simultaneously
+  - **Pros**: No user disruption  
+  - **Cons**: Increased complexity, maintenance burden, rejected per requirements
+
+## Phase Breakdown
+
+### Phase 1: Configuration Update — Update default paths — Low — none
+**Goal**: Change default configuration to point to new file location
+**Deliverables**:
+- Updated `package.json` default value
+- Updated fallback defaults in code
+
+**Success Criteria**:
+- All installations use `.github/instructions/todos.instructions.md` by default
+- Existing users automatically switch to new path on next update
+
+### Phase 2: Template Enhancement — Add frontmatter template — Low — Phase 1
+**Goal**: Add frontmatter to the generated file template
+**Deliverables**:
+- Updated template in both `CopilotInstructionsManager` and `StandaloneCopilotWriter`
+- Preserved existing XML structure
+
+**Success Criteria**:
+- New files include the required frontmatter
+- Existing files preserve existing frontmatter and add todos section
+- XML todos structure remains functional
+
+### Phase 3: Directory Handling — Ensure nested directory creation — Low — Phase 1
+**Goal**: Handle creation of nested `.github/instructions/` directory
+**Deliverables**:
+- Enhanced directory creation logic in both implementations
+- Validation that nested paths work correctly
+
+**Success Criteria**:
+- Directory creation works for nested paths
+- File operations succeed in new directory structure
+- Error handling for directory creation failures
+
+## Component Map
+
+- `package.json`: configuration default (modify) — Update default autoInjectFilePath value
+- `src/copilotInstructionsManager.ts`: template format (modify) — Add frontmatter to updateInstructionsWithTodos method
+- `src/mcp/standaloneCopilotWriter.ts`: template format (modify) — Add frontmatter to updateInstructionsWithTodos method
+- `src/todoManager.ts`: fallback default (modify) — Update getAutoInjectFilePath default value  
+- `src/mcp/standaloneTodoManager.ts`: fallback default (modify) — Update constructor default parameter
+- `.github/copilot-instructions.md`: architecture documentation (modify) — Update references to new default path
+
+## Data Architecture
+
+### Template Structure Changes
+**Current Structure:**
+```
+<todos title="..." rule="...">
+${todoMarkdown}
+</todos>
+```
+
+**New Structure:**
+```yaml
+---
+applyTo: '**'
+---
+
+<todos title="..." rule="...">
+${todoMarkdown}
+</todos>
+```
+
+### File Path Changes
+- **Old Default**: `.github/copilot-instructions.md`
+- **New Default**: `.github/instructions/todos.instructions.md`
+- **Directory**: Will auto-create `.github/instructions/` if needed
+
+## Testing Strategy
+
+### Unit Test Requirements
+- Verify frontmatter is added to new files only when missing
+- Verify existing frontmatter is preserved when present
+- Test directory creation for nested paths
+- Validate template format matches requirements
+- Test new default path behavior
+
+### Integration Test Scenarios
+- Create new todos with new default path
+- Update existing todos, preserving existing frontmatter
+- Handle directory creation failures gracefully
+- Verify file content structure after updates
+
+### E2E Validation
+- Test VS Code extension with new defaults
+- Test standalone MCP server with new defaults
+- Verify new file creation in clean workspace
+- Test frontmatter preservation with existing files
+
+## Risk Analysis
+
+### Risk: Directory Creation Failures
+**Mitigation**: Enhanced error handling with fallback directory creation
+**Monitoring**: Log directory creation attempts and failures
+
+### Risk: Frontmatter Detection
+**Description**: Need to detect existing frontmatter to avoid duplication
+**Mitigation**: Simple regex check for existing frontmatter before adding
+**Monitoring**: Log frontmatter detection and addition
+
+### Risk: User File Location Change
+**Description**: Users will need to update their workflows for new file location
+**Mitigation**: Update documentation and consider notification message
+**Monitoring**: Track usage of new vs old file paths
+
+## Tasks
+
+- [x] TASK-1: Update package.json default configuration — CONFIG-1 — S — none
+  - **Acceptance**: `agentTodos.autoInjectFilePath` default changed to `.github/instructions/todos.instructions.md`
+  
+- [x] TASK-2: Update CopilotInstructionsManager template — TEMPLATE-1 — M — TASK-1
+  - **Acceptance**: Frontmatter added only if missing before `<todos>` section in updateInstructionsWithTodos method
+  
+- [x] TASK-3: Update StandaloneCopilotWriter template — TEMPLATE-1 — M — TASK-1
+  - **Acceptance**: Frontmatter added only if missing before `<todos>` section in updateInstructionsWithTodos method
+  
+- [x] TASK-4: Update TodoManager fallback default — CONFIG-1 — S — TASK-1
+  - **Acceptance**: getAutoInjectFilePath method uses new default when VS Code config unavailable
+  
+- [x] TASK-5: Update StandaloneTodoManager fallback default — CONFIG-1 — S — TASK-1
+  - **Acceptance**: StandaloneCopilotWriter constructor uses new default file path
+  
+- [x] TASK-6: Enhance directory creation logic — INFRA-1 — M — none
+  - **Acceptance**: Both implementations handle nested directory creation correctly
+  
+- [x] TASK-7: Update architecture documentation — DOC-1 — S — TASK-1
+  - **Acceptance**: References to file paths updated in .github/copilot-instructions.md
+
+## Decisions Log
+
+- **2025-01-19**: Chose direct update strategy over backward compatibility to simplify implementation
+- **2025-01-19**: Decided to preserve existing frontmatter and only add when missing
+- **2025-01-19**: Selected simple string template approach without YAML validation
+- **2025-01-19**: All users will get new default file path behavior
+- **2025-01-19**: TASK-1 completed - Updated all default configuration paths from `.github/copilot-instructions.md` to `.github/instructions/todos.instructions.md` in package.json, todoManager.ts, copilotInstructionsManager.ts, and standaloneCopilotWriter.ts
+- **2025-01-19**: TASK-2 completed - Added frontmatter detection and addition to CopilotInstructionsManager with tests
+- **2025-01-19**: TASK-3 completed - Added frontmatter detection and addition to StandaloneCopilotWriter with tests  
+- **2025-01-19**: TASK-4,5 completed as part of TASK-1 - All fallback defaults updated
+- **2025-01-19**: TASK-6 verified complete - Directory creation already working with recursive: true
+- **2025-01-19**: TASK-7 completed - Updated all documentation references to new default paths
+- **2025-01-19**: **BUG FIX** - Fixed frontmatter accumulation issue where frontmatter was being added after todos section instead of preserved from original file, causing multiple frontmatter blocks to accumulate. Root cause: Logic was checking for frontmatter AFTER prepending todos section, not before. Solution: Check original content for frontmatter first, then either preserve existing frontmatter or add new frontmatter appropriately.
+
+## Open Questions & Decisions
+
+### Requirements
+- **Q1**: Should we provide any user notification about the file path change?
+  - **Context**: Users will see their todos appear in a new file location
+  - **Impact**: User awareness and workflow adaptation
+  - **Recommendation**: Add one-time notification or update documentation prominently
+
+### Technical  
+- **D1**: Use simple string detection for frontmatter presence
+  - **Approach**: Check if file starts with `---` to detect existing frontmatter
+  - **Pros**: Simple, reliable, no parsing required
+  - **Cons**: Could false positive on non-frontmatter content starting with `---`
+  - **Decision**: Use regex check for `^---\n.*?\n---\n` pattern
+
+### Architecture
+- **Q2**: Should the frontmatter template be configurable?
+  - **Context**: Users might want different `applyTo` values
+  - **Impact**: Determines if we need additional configuration options
+  - **Recommendation**: Keep it fixed for now, can add configuration later if needed
+
+**PAUSE FOR FEEDBACK**
+
+## Implementation Status: COMPLETE ✅
+
+All tasks have been successfully implemented and tested:
+
+### Completed Features
+1. **Default Path Change**: All users now use `.github/instructions/todos.instructions.md` by default
+2. **Frontmatter Template**: Automatically adds `applyTo: '**'` frontmatter when missing
+3. **Frontmatter Preservation**: Existing frontmatter is preserved during updates
+4. **Directory Creation**: Nested directory structure is created automatically
+5. **Documentation Updates**: All references updated to new paths
+
+### Implementation Summary
+- ✅ Updated 4 files for default path configuration
+- ✅ Added frontmatter detection and addition logic to both VS Code and standalone modes
+- ✅ Created comprehensive test suites for new functionality
+- ✅ Updated all documentation and UI text references
+- ✅ Verified directory creation works for nested paths
+- ✅ Created integration tests covering complete workflow
+
+### Breaking Changes
+- **Default file location changed** from `.github/copilot-instructions.md` to `.github/instructions/todos.instructions.md`
+- **Frontmatter added automatically** to all generated files with `applyTo: '**'`
+- **Command titles updated** to be generic instead of file-specific
+
+All changes maintain backward compatibility for users who have customized the file path setting.

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
       },
       {
         "command": "agentTodos.toggleAutoInject",
-        "title": "Enable auto-inject into copilot-instructions.md",
+        "title": "Enable auto-inject into instructions file",
         "category": "Agent TODOs",
         "icon": "$(sync)"
       },
       {
         "command": "agentTodos.toggleAutoInjectEnabled",
-        "title": "Disable auto-inject into copilot-instructions.md",
+        "title": "Disable auto-inject into instructions file",
         "category": "Agent TODOs",
         "icon": "$(sync)"
       },
@@ -271,7 +271,7 @@
         },
         "agentTodos.autoInjectFilePath": {
           "type": "string",
-          "default": ".github/copilot-instructions.md",
+          "default": ".github/instructions/todos.instructions.md",
           "description": "File path for auto-inject feature. Can be relative to workspace root or absolute path."
         },
         "agentTodos.autoOpenView": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				await config.update('autoInject', !currentValue, vscode.ConfigurationTarget.Workspace);
 
 				const status = !currentValue ? 'enabled' : 'disabled';
-				vscode.window.showInformationMessage(`Auto-inject ${status}. Todo list will ${!currentValue ? 'now be automatically injected into' : 'be removed from'} .github/copilot-instructions.md`);
+				vscode.window.showInformationMessage(`Auto-inject ${status}. Todo list will ${!currentValue ? 'now be automatically injected into' : 'be removed from'} instructions file`);
 				
 				telemetryManager.sendEvent('command.toggleAutoInject', {
 					newValue: String(!currentValue)
@@ -192,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			await config.update('autoInject', !currentValue, vscode.ConfigurationTarget.Workspace);
 
 			const status = !currentValue ? 'enabled' : 'disabled';
-			vscode.window.showInformationMessage(`Auto-inject ${status}. Todo list will ${!currentValue ? 'now be automatically injected into' : 'be removed from'} .github/copilot-instructions.md`);
+			vscode.window.showInformationMessage(`Auto-inject ${status}. Todo list will ${!currentValue ? 'now be automatically injected into' : 'be removed from'} instructions file`);
 		});
 
 		const toggleAutoOpenViewCommand = vscode.commands.registerCommand('agentTodos.toggleAutoOpenView', async () => {

--- a/src/mcp/mcpProvider.ts
+++ b/src/mcp/mcpProvider.ts
@@ -57,7 +57,7 @@ export class TodoMCPServerProvider implements vscode.McpServerDefinitionProvider
         // Get current configuration
         const config = vscode.workspace.getConfiguration('agentTodos');
         const autoInject = config.get<boolean>('autoInject', false);
-        const autoInjectFilePath = config.get<string>('autoInjectFilePath', '.github/copilot-instructions.md');
+        const autoInjectFilePath = config.get<string>('autoInjectFilePath', '.github/instructions/todos.instructions.md');
 
         console.log('[TodoMCPProvider] Configuration:', { autoInject, autoInjectFilePath });
 
@@ -175,7 +175,7 @@ export class TodoMCPServerProvider implements vscode.McpServerDefinitionProvider
           const config = vscode.workspace.getConfiguration('agentTodos');
           const autoInject = config.get<boolean>('autoInject', false);
           const enableSubtasks = config.get<boolean>('enableSubtasks', true);
-          const autoInjectFilePath = config.get<string>('autoInjectFilePath', '.github/copilot-instructions.md');
+          const autoInjectFilePath = config.get<string>('autoInjectFilePath', '.github/instructions/todos.instructions.md');
 
           // Broadcast configuration change to MCP server
           this.server.broadcastUpdate({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -45,7 +45,7 @@ export class TodoMCPServer {
       workspaceRoot: config.workspaceRoot || process.cwd(),
       standalone: config.standalone === true,
       autoInject: config.autoInject || false,
-      autoInjectFilePath: config.autoInjectFilePath || '.github/copilot-instructions.md'
+      autoInjectFilePath: config.autoInjectFilePath || '.github/instructions/todos.instructions.md'
     };
 
     console.log(`📋 Final config:`, this.config);
@@ -1081,7 +1081,7 @@ CRITICAL: Keep planning until the user's request is FULLY broken down. Do not st
     const reminder = inProgressTaskCount === 0 && pendingCount > 0 ? '\nReminder: Mark a task as in_progress BEFORE starting work on it.' : '';
 
     const autoInjectNote = this.isAutoInjectEnabled() && !this.config.standalone
-      ? '\nNote: Todos are automatically synced to <todos> in .github/copilot-instructions.md'
+      ? '\nNote: Todos are automatically synced to <todos> in instructions file'
       : '';
 
     const titleMsg = title ? ` and title to "${title}"` : '';

--- a/src/mcp/standalone.ts
+++ b/src/mcp/standalone.ts
@@ -7,7 +7,7 @@ async function startStandaloneServer() {
   const port = parseInt(process.env.MCP_PORT || '3000', 10);
   const workspaceRoot = process.env.WORKSPACE_ROOT || process.cwd();
   const autoInject = process.env.MCP_AUTO_INJECT === 'true' || process.argv.includes('--auto-inject');
-  const autoInjectFilePath = process.env.MCP_AUTO_INJECT_FILE_PATH || '.github/copilot-instructions.md';
+  const autoInjectFilePath = process.env.MCP_AUTO_INJECT_FILE_PATH || '.github/instructions/todos.instructions.md';
   
   console.log('Starting MCP Todo Server in standalone mode...');
   console.log(`Workspace root: ${workspaceRoot}`);

--- a/src/mcp/tools/todoTools.ts
+++ b/src/mcp/tools/todoTools.ts
@@ -366,7 +366,7 @@ CRITICAL: Keep planning until the user's request is FULLY broken down. Do not st
     const reminder = inProgressTaskCount === 0 && pendingCount > 0 ? '\nReminder: Mark a task as in_progress BEFORE starting work on it.' : '';
 
     const autoInjectNote = this.isAutoInjectEnabled() && !this.server.isStandalone()
-      ? '\nNote: Todos are automatically synced to <todos> in .github/copilot-instructions.md'
+      ? '\nNote: Todos are automatically synced to <todos> in instructions file'
       : '';
 
     const titleMsg = title ? ` and title to "${title}"` : '';

--- a/src/test/autoInjectIntegration.test.ts
+++ b/src/test/autoInjectIntegration.test.ts
@@ -1,0 +1,230 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { StandaloneCopilotWriter } from '../mcp/standaloneCopilotWriter';
+import { CopilotInstructionsManager } from '../copilotInstructionsManager';
+import { TodoItem } from '../types';
+
+suite('AutoInject Feature Integration Tests', () => {
+    let tempDir: string;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autoinject-integration-test-'));
+    });
+
+    teardown(() => {
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    suite('Default Path Configuration', () => {
+        test('StandaloneCopilotWriter should use new default path', () => {
+            const writer = new StandaloneCopilotWriter(tempDir);
+            const pathMethod = (writer as any).getInstructionsPath.bind(writer);
+            
+            const path = pathMethod();
+            assert.ok(path.endsWith('.github/instructions/todos.instructions.md'));
+        });
+
+        test('CopilotInstructionsManager should use new default path', () => {
+            const manager = CopilotInstructionsManager.getInstance();
+            const pathMethod = (manager as any).getConfiguredFilePath.bind(manager);
+            
+            // This will use the fallback since VS Code isn't available in tests
+            const path = pathMethod();
+            assert.strictEqual(path, '.github/instructions/todos.instructions.md');
+        });
+    });
+
+    suite('Frontmatter Integration', () => {
+        test('Should create complete file with frontmatter and todos', async () => {
+            const writer = new StandaloneCopilotWriter(tempDir);
+            const todos: TodoItem[] = [
+                { id: 'integration-1', content: 'Test integration', status: 'pending', priority: 'high' }
+            ];
+
+            await writer.updateInstructionsWithTodos(todos, 'Integration Test');
+
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            assert.ok(fs.existsSync(filePath), 'File should be created');
+
+            const content = fs.readFileSync(filePath, 'utf8');
+            
+            // Check frontmatter
+            assert.ok(content.startsWith('---\napplyTo: \'**\'\n---\n\n'));
+            
+            // Check todos section
+            assert.ok(content.includes('<todos title="Integration Test"'));
+            assert.ok(content.includes('Test integration'));
+            
+            // Check complete structure
+            const lines = content.split('\n');
+            assert.strictEqual(lines[0], '---');
+            assert.strictEqual(lines[1], 'applyTo: \'**\'');
+            assert.strictEqual(lines[2], '---');
+            assert.strictEqual(lines[3], '');
+            assert.ok(lines[4].includes('Auto-generated todo section'));
+        });
+
+        test('Should preserve existing frontmatter during updates', async () => {
+            const writer = new StandaloneCopilotWriter(tempDir);
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            
+            // Create directory and initial file with custom frontmatter
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const initialContent = `---
+title: Custom Instructions
+applyTo: '*.ts'
+version: 2.0
+---
+
+# Existing Instructions
+
+Some custom content here.
+`;
+            fs.writeFileSync(filePath, initialContent, 'utf8');
+
+            const todos: TodoItem[] = [
+                { id: 'preserve-1', content: 'Preserve frontmatter test', status: 'in_progress', priority: 'medium' }
+            ];
+
+            await writer.updateInstructionsWithTodos(todos);
+
+            const updatedContent = fs.readFileSync(filePath, 'utf8');
+            
+            // Should preserve all custom frontmatter fields
+            assert.ok(updatedContent.includes('title: Custom Instructions'));
+            assert.ok(updatedContent.includes('applyTo: \'*.ts\''));
+            assert.ok(updatedContent.includes('version: 2.0'));
+            
+            // Should include new todos
+            assert.ok(updatedContent.includes('<todos rule='));
+            assert.ok(updatedContent.includes('Preserve frontmatter test'));
+            
+            // Should preserve existing content
+            assert.ok(updatedContent.includes('# Existing Instructions'));
+            assert.ok(updatedContent.includes('Some custom content here.'));
+            
+            // Should not add the default frontmatter since custom frontmatter exists
+            assert.strictEqual(updatedContent.indexOf('applyTo: \'**\''), -1);
+        });
+    });
+
+    suite('Directory Creation', () => {
+        test('Should create nested directories for new default path', async () => {
+            const writer = new StandaloneCopilotWriter(tempDir);
+            const todos: TodoItem[] = [
+                { id: 'nested-1', content: 'Nested directory test', status: 'completed', priority: 'low' }
+            ];
+
+            await writer.updateInstructionsWithTodos(todos);
+
+            // Verify nested directory structure was created
+            const githubDir = path.join(tempDir, '.github');
+            const instructionsDir = path.join(tempDir, '.github/instructions');
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            
+            assert.ok(fs.existsSync(githubDir), '.github directory should exist');
+            assert.ok(fs.existsSync(instructionsDir), '.github/instructions directory should exist');
+            assert.ok(fs.existsSync(filePath), 'todos.instructions.md file should exist');
+
+            const content = fs.readFileSync(filePath, 'utf8');
+            assert.ok(content.includes('Nested directory test'));
+        });
+    });
+
+    suite('Frontmatter Accumulation Bug Fix', () => {
+        test('Should not accumulate frontmatter on multiple todo updates', async () => {
+            const writer = new StandaloneCopilotWriter(tempDir);
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            
+            // First update - creates file with frontmatter
+            const todos1: TodoItem[] = [
+                { id: 'bug-test-1', content: 'First todo', status: 'pending', priority: 'high' }
+            ];
+            await writer.updateInstructionsWithTodos(todos1, 'First Update');
+
+            let content = fs.readFileSync(filePath, 'utf8');
+            let frontmatterCount = (content.match(/^---\n/gm) || []).length;
+            assert.strictEqual(frontmatterCount, 1, 'Should have exactly one frontmatter section after first update');
+
+            // Second update - should not add more frontmatter
+            const todos2: TodoItem[] = [
+                { id: 'bug-test-1', content: 'First todo', status: 'completed', priority: 'high' },
+                { id: 'bug-test-2', content: 'Second todo', status: 'pending', priority: 'medium' }
+            ];
+            await writer.updateInstructionsWithTodos(todos2, 'Second Update');
+
+            content = fs.readFileSync(filePath, 'utf8');
+            frontmatterCount = (content.match(/^---\n/gm) || []).length;
+            assert.strictEqual(frontmatterCount, 1, 'Should still have exactly one frontmatter section after second update');
+
+            // Third update - should still not accumulate
+            const todos3: TodoItem[] = [
+                { id: 'bug-test-2', content: 'Second todo', status: 'completed', priority: 'medium' },
+                { id: 'bug-test-3', content: 'Third todo', status: 'in_progress', priority: 'low' }
+            ];
+            await writer.updateInstructionsWithTodos(todos3, 'Third Update');
+
+            content = fs.readFileSync(filePath, 'utf8');
+            frontmatterCount = (content.match(/^---\n/gm) || []).length;
+            assert.strictEqual(frontmatterCount, 1, 'Should still have exactly one frontmatter section after third update');
+
+            // Verify content structure is correct
+            assert.ok(content.startsWith('---\napplyTo: \'**\'\n---\n\n'));
+            assert.ok(content.includes('Third Update'));
+            assert.ok(content.includes('Third todo'));
+            assert.ok(content.includes('in_progress'));
+        });
+
+        test('Should preserve custom frontmatter across multiple updates', async () => {
+            const writer = new StandaloneCopilotWriter(tempDir);
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            
+            // Create initial file with custom frontmatter
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const initialContent = `---
+title: Custom Instructions
+applyTo: '*.ts'
+version: 2.0
+author: test
+---
+
+# Custom Instructions
+
+Some custom content.
+`;
+            fs.writeFileSync(filePath, initialContent, 'utf8');
+
+            // Multiple updates should preserve the custom frontmatter
+            for (let i = 1; i <= 3; i++) {
+                const todos: TodoItem[] = [
+                    { id: `preserve-${i}`, content: `Update ${i} todo`, status: 'pending', priority: 'medium' }
+                ];
+                await writer.updateInstructionsWithTodos(todos, `Update ${i}`);
+
+                const content = fs.readFileSync(filePath, 'utf8');
+                
+                // Should preserve all custom frontmatter fields
+                assert.ok(content.includes('title: Custom Instructions'));
+                assert.ok(content.includes('applyTo: \'*.ts\''));
+                assert.ok(content.includes('version: 2.0'));
+                assert.ok(content.includes('author: test'));
+                
+                // Should not have our default frontmatter
+                assert.strictEqual(content.indexOf('applyTo: \'**\''), -1);
+                
+                // Should have only one frontmatter section
+                const frontmatterCount = (content.match(/^---\n/gm) || []).length;
+                assert.strictEqual(frontmatterCount, 1, `Should have exactly one frontmatter section after update ${i}`);
+                
+                // Should include the updated todo
+                assert.ok(content.includes(`Update ${i} todo`));
+                assert.ok(content.includes('# Custom Instructions'));
+                assert.ok(content.includes('Some custom content.'));
+            }
+        });
+    });
+});

--- a/src/test/standaloneCopilotWriter.test.ts
+++ b/src/test/standaloneCopilotWriter.test.ts
@@ -1,0 +1,207 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { StandaloneCopilotWriter } from '../mcp/standaloneCopilotWriter';
+import { TodoItem } from '../types';
+
+suite('StandaloneCopilotWriter Tests', () => {
+    let tempDir: string;
+    let writer: StandaloneCopilotWriter;
+
+    setup(() => {
+        // Create temp directory for testing
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'standalone-writer-test-'));
+        writer = new StandaloneCopilotWriter(tempDir);
+    });
+
+    teardown(() => {
+        // Clean up temp directory
+        if (fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    suite('Frontmatter Detection', () => {
+        test('Should detect when frontmatter is missing', () => {
+            const content = '<todos>Some content</todos>';
+            const hasFrontmatterMethod = (writer as any).hasFrontmatter.bind(writer);
+            
+            const result = hasFrontmatterMethod(content);
+            assert.strictEqual(result, false);
+        });
+
+        test('Should detect when frontmatter is present', () => {
+            const content = `---
+applyTo: '**'
+---
+
+<todos>Some content</todos>`;
+            const hasFrontmatterMethod = (writer as any).hasFrontmatter.bind(writer);
+            
+            const result = hasFrontmatterMethod(content);
+            assert.strictEqual(result, true);
+        });
+
+        test('Should detect frontmatter with different content', () => {
+            const content = `---
+title: My Instructions
+applyTo: '*.ts'
+---
+
+Some content here`;
+            const hasFrontmatterMethod = (writer as any).hasFrontmatter.bind(writer);
+            
+            const result = hasFrontmatterMethod(content);
+            assert.strictEqual(result, true);
+        });
+
+        test('Should not detect false positives', () => {
+            const content = `This is not frontmatter
+---
+Even though it has dashes
+---
+It should not be detected as frontmatter`;
+            const hasFrontmatterMethod = (writer as any).hasFrontmatter.bind(writer);
+            
+            const result = hasFrontmatterMethod(content);
+            assert.strictEqual(result, false);
+        });
+    });
+
+    suite('Frontmatter Addition', () => {
+        test('Should add frontmatter to content without it', () => {
+            const content = '<todos>Some todos</todos>';
+            const addFrontmatterMethod = (writer as any).addFrontmatter.bind(writer);
+            
+            const result = addFrontmatterMethod(content);
+            
+            assert.ok(result.startsWith('---\napplyTo: \'**\'\n---\n\n'));
+            assert.ok(result.includes('<todos>Some todos</todos>'));
+        });
+
+        test('Should preserve existing frontmatter', () => {
+            const content = `---
+title: Existing
+applyTo: '*.js'
+---
+
+<todos>Some todos</todos>`;
+            const addFrontmatterMethod = (writer as any).addFrontmatter.bind(writer);
+            
+            const result = addFrontmatterMethod(content);
+            
+            assert.strictEqual(result, content); // Should be unchanged
+            assert.ok(result.includes('title: Existing'));
+            assert.ok(result.includes('applyTo: \'*.js\''));
+        });
+
+        test('Should not accumulate frontmatter on multiple updates', () => {
+            // Simulate multiple updates to the same file content
+            const hasMethod = (writer as any).hasFrontmatter.bind(writer);
+            
+            // Initial content with our frontmatter
+            let content = `---
+applyTo: '**'
+---
+
+<todos>Initial todos</todos>
+Some existing content`;
+
+            // First update - should preserve frontmatter
+            const hasFrontmatter1 = hasMethod(content);
+            assert.strictEqual(hasFrontmatter1, true, 'Should detect existing frontmatter');
+
+            // Simulate removing todos and re-adding (like in updateInstructionsWithTodos)
+            const contentWithoutTodos = content.replace(/<todos[^>]*>[\s\S]*?<\/todos>\s*\n?/, '');
+            const newTodos = '<todos>Updated todos</todos>\n\n';
+            
+            // Check frontmatter before prepending todos
+            const frontmatterMatch = content.match(/^(---\n.*?\n---\n\n?)/s);
+            assert.ok(frontmatterMatch, 'Should match frontmatter regex');
+            
+            const frontmatter = frontmatterMatch[1];
+            const contentAfterFrontmatter = contentWithoutTodos.replace(frontmatterMatch[1], '');
+            const finalContent = frontmatter + newTodos + contentAfterFrontmatter;
+
+            // Should still have only one frontmatter section
+            const frontmatterCount = (finalContent.match(/^---\n/gm) || []).length;
+            assert.strictEqual(frontmatterCount, 1, 'Should have exactly one frontmatter section');
+            
+            assert.ok(finalContent.includes('Updated todos'));
+            assert.ok(finalContent.includes('Some existing content'));
+        });
+    });
+
+    suite('File Operations with Frontmatter', () => {
+        test('Should add frontmatter to new file', async () => {
+            const todos: TodoItem[] = [
+                { id: 'test-1', content: 'Test todo', status: 'pending', priority: 'medium' }
+            ];
+
+            await writer.updateInstructionsWithTodos(todos, 'Test Title');
+
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            assert.ok(fs.existsSync(filePath), 'File should be created');
+
+            const content = fs.readFileSync(filePath, 'utf8');
+            assert.ok(content.startsWith('---\napplyTo: \'**\'\n---\n\n'));
+            assert.ok(content.includes('<todos title="Test Title"'));
+            assert.ok(content.includes('Test todo'));
+        });
+
+        test('Should preserve existing frontmatter when updating', async () => {
+            const filePath = path.join(tempDir, '.github/instructions/todos.instructions.md');
+            
+            // Create directory first
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            
+            // Write initial content with custom frontmatter
+            const initialContent = `---
+title: Custom Instructions
+applyTo: '*.ts'
+customField: value
+---
+
+Some existing content
+`;
+            fs.writeFileSync(filePath, initialContent, 'utf8');
+
+            const todos: TodoItem[] = [
+                { id: 'test-1', content: 'New todo', status: 'pending', priority: 'high' }
+            ];
+
+            await writer.updateInstructionsWithTodos(todos);
+
+            const updatedContent = fs.readFileSync(filePath, 'utf8');
+            
+            // Should preserve custom frontmatter
+            assert.ok(updatedContent.includes('title: Custom Instructions'));
+            assert.ok(updatedContent.includes('applyTo: \'*.ts\''));
+            assert.ok(updatedContent.includes('customField: value'));
+            
+            // Should include new todos
+            assert.ok(updatedContent.includes('<todos rule='));
+            assert.ok(updatedContent.includes('New todo'));
+            
+            // Should preserve existing content
+            assert.ok(updatedContent.includes('Some existing content'));
+        });
+
+        test('Should handle nested directory creation', async () => {
+            const customWriter = new StandaloneCopilotWriter(tempDir, 'deep/nested/path/todos.md');
+            const todos: TodoItem[] = [
+                { id: 'test-1', content: 'Deep todo', status: 'pending', priority: 'low' }
+            ];
+
+            await customWriter.updateInstructionsWithTodos(todos);
+
+            const filePath = path.join(tempDir, 'deep/nested/path/todos.md');
+            assert.ok(fs.existsSync(filePath), 'File should be created in nested directory');
+
+            const content = fs.readFileSync(filePath, 'utf8');
+            assert.ok(content.startsWith('---\napplyTo: \'**\'\n---\n\n'));
+            assert.ok(content.includes('Deep todo'));
+        });
+    });
+});

--- a/src/todoManager.ts
+++ b/src/todoManager.ts
@@ -93,9 +93,9 @@ export class TodoManager {
 
     private getAutoInjectFilePath(): string {
         try {
-            return vscode.workspace.getConfiguration('agentTodos').get<string>('autoInjectFilePath', '.github/copilot-instructions.md');
+            return vscode.workspace.getConfiguration('agentTodos').get<string>('autoInjectFilePath', '.github/instructions/todos.instructions.md');
         } catch (error) {
-            return '.github/copilot-instructions.md'; // Default when vscode is not available
+            return '.github/instructions/todos.instructions.md'; // Default when vscode is not available
         }
     }
 


### PR DESCRIPTION
- Fixed frontmatter accumulation bug where multiple updates caused duplicate frontmatter blocks
- Updated default autoInject file path to .github/instructions/todos.instructions.md
- Added frontmatter template with applyTo: '**' for new instruction files
- Enhanced frontmatter detection to check original content before modifications
- Added comprehensive test coverage for frontmatter handling
- Updated all references to new default file paths in code and documentation